### PR TITLE
fix(e2e): stabilize test-cases Playwright suite with API cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,13 +12,13 @@ Single-package **QA Studio** app (SvelteKit 2 + Svelte 5 + Prisma + PostgreSQL).
 
 The VM typically provides these via injected secrets (no `.env.local` required if set at process level):
 
-| Variable | Purpose |
-|----------|---------|
-| `DATABASE_URL` | PostgreSQL (Neon or local) |
-| `SESSION_SECRET` | Session HMAC |
-| `TOTP_ENCRYPTION_KEY` | 64 hex chars (`openssl rand -hex 32`) |
-| `BLOB_READ_WRITE_TOKEN` | Vercel Blob for attachments |
-| `ENCRYPTION_KEY`, `URL_SIGNING_SECRET` | Integrations / signed trace URLs |
+| Variable                               | Purpose                               |
+| -------------------------------------- | ------------------------------------- |
+| `DATABASE_URL`                         | PostgreSQL (Neon or local)            |
+| `SESSION_SECRET`                       | Session HMAC                          |
+| `TOTP_ENCRYPTION_KEY`                  | 64 hex chars (`openssl rand -hex 32`) |
+| `BLOB_READ_WRITE_TOKEN`                | Vercel Blob for attachments           |
+| `ENCRYPTION_KEY`, `URL_SIGNING_SECRET` | Integrations / signed trace URLs      |
 
 Optional but common: Upstash Redis REST URL/token (`KV_*`); caching is disabled in dev if unset. Set self-hosted mode (`SELF_HOSTED=true`) to skip Stripe/subscription gates for local full-feature testing.
 
@@ -36,25 +36,25 @@ npx @inlang/paraglide-js compile --project ./project.inlang --outdir ./src/lib/p
 
 ### Services
 
-| Service | Local dev |
-|---------|-----------|
-| **App** | `npm run dev` (port 3000) |
-| **PostgreSQL** | Use `DATABASE_URL` from env, or `docker compose up postgres` (Docker optional) |
+| Service            | Local dev                                                                                                                   |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| **App**            | `npm run dev` (port 3000)                                                                                                   |
+| **PostgreSQL**     | Use `DATABASE_URL` from env, or `docker compose up postgres` (Docker optional)                                              |
 | **Playwright E2E** | Default config hits production `the hosted deployment`; local E2E needs `webServer` + credentials in `playwright.config.ts` |
 
 Docker Compose (`npm run docker:dev`) includes Redis/MinIO/MailHog, but the app code uses **Upstash** (`KV_*`) and **Vercel Blob**, not the compose Redis/MinIO env vars.
 
 ### Standard commands
 
-| Task | Command |
-|------|---------|
-| Install | `npm install` |
-| DB schema | `npx prisma migrate deploy` (or `db push` for throwaway DBs) |
-| Lint | `npm run lint` (large pre-existing eslint backlog in repo) |
-| Typecheck | `npm run check` |
-| Unit tests | `npm run test:unit -- --run` |
-| Build | `npm run build` |
-| Dev | `npm run dev` |
+| Task       | Command                                                      |
+| ---------- | ------------------------------------------------------------ |
+| Install    | `npm install`                                                |
+| DB schema  | `npx prisma migrate deploy` (or `db push` for throwaway DBs) |
+| Lint       | `npm run lint` (large pre-existing eslint backlog in repo)   |
+| Typecheck  | `npm run check`                                              |
+| Unit tests | `npm run test:unit -- --run`                                 |
+| Build      | `npm run build`                                              |
+| Dev        | `npm run dev`                                                |
 
 ### Long-running processes
 

--- a/e2e/helpers/cleanup.ts
+++ b/e2e/helpers/cleanup.ts
@@ -1,0 +1,116 @@
+import type { APIRequestContext } from '@playwright/test';
+import { ApiClient } from '../pages/api';
+
+/** Prefix used by test-cases E2E tests for created resources */
+export const E2E_RESOURCE_PREFIX = 'E2E ';
+
+export function getApiClient(request: APIRequestContext): ApiClient {
+	const apiKey = process.env.QA_STUDIO_API_KEY;
+	if (!apiKey) {
+		throw new Error('QA_STUDIO_API_KEY is required for E2E cleanup');
+	}
+	return new ApiClient(request, '', apiKey);
+}
+
+export function getE2eProjectId(): string {
+	const projectId = process.env.QA_STUDIO_PROJECT_ID;
+	if (!projectId) {
+		throw new Error('QA_STUDIO_PROJECT_ID is required for test-cases E2E tests');
+	}
+	return projectId;
+}
+
+function isE2eResourceName(name: string): boolean {
+	return name.startsWith(E2E_RESOURCE_PREFIX) || name.startsWith('E2E');
+}
+
+type SuiteNode = {
+	id: string;
+	name: string;
+	children?: SuiteNode[];
+};
+
+function flattenSuites(
+	suites: SuiteNode[],
+	depth = 0
+): Array<{ id: string; name: string; depth: number }> {
+	const flat: Array<{ id: string; name: string; depth: number }> = [];
+	for (const suite of suites) {
+		flat.push({ id: suite.id, name: suite.name, depth });
+		if (suite.children?.length) {
+			flat.push(...flattenSuites(suite.children, depth + 1));
+		}
+	}
+	return flat;
+}
+
+/**
+ * Remove E2E test cases and suites left over from previous runs.
+ * Uses the API so cleanup works even when UI tests fail mid-flight.
+ */
+export async function cleanupE2eTestData(
+	request: APIRequestContext,
+	projectId: string
+): Promise<{ casesDeleted: number; suitesDeleted: number }> {
+	const api = getApiClient(request);
+	let casesDeleted = 0;
+	let suitesDeleted = 0;
+
+	let page = 1;
+	let hasMore = true;
+
+	while (hasMore) {
+		const response = await api.listTestCases(projectId, {
+			search: 'E2E',
+			page,
+			limit: 100
+		});
+
+		if (!response.ok()) {
+			break;
+		}
+
+		const body = await api.getResponseBody(response);
+		const cases: Array<{ id: string; title: string }> = body.data ?? [];
+
+		if (cases.length === 0) {
+			break;
+		}
+
+		for (const testCase of cases) {
+			if (!isE2eResourceName(testCase.title)) {
+				continue;
+			}
+			const deleted = await api.deleteTestCase(projectId, testCase.id);
+			if (deleted.ok()) {
+				casesDeleted++;
+			}
+		}
+
+		hasMore = Boolean(body.pagination?.hasMore);
+		page += 1;
+	}
+
+	const suitesResponse = await api.listSuites(projectId);
+	if (suitesResponse.ok()) {
+		const suites = (await api.getResponseBody(suitesResponse)) as SuiteNode[];
+		const e2eSuites = flattenSuites(suites)
+			.filter((suite) => isE2eResourceName(suite.name))
+			.sort((a, b) => b.depth - a.depth);
+
+		for (const suite of e2eSuites) {
+			const deleted = await api.deleteSuite(projectId, suite.id);
+			if (deleted.ok()) {
+				suitesDeleted++;
+			}
+		}
+	}
+
+	if (casesDeleted > 0 || suitesDeleted > 0) {
+		console.log(
+			`✓ E2E cleanup for project ${projectId}: ${casesDeleted} case(s), ${suitesDeleted} suite(s)`
+		);
+	}
+
+	return { casesDeleted, suitesDeleted };
+}

--- a/e2e/pages/api.ts
+++ b/e2e/pages/api.ts
@@ -230,10 +230,7 @@ export class ApiClient {
 	/**
 	 * List test suites for a project
 	 */
-	async listSuites(
-		projectId: string,
-		params?: { parentId?: string }
-	): Promise<APIResponse> {
+	async listSuites(projectId: string, params?: { parentId?: string }): Promise<APIResponse> {
 		const searchParams = new URLSearchParams();
 		if (params?.parentId) {
 			searchParams.set('parentId', params.parentId);

--- a/e2e/pages/api.ts
+++ b/e2e/pages/api.ts
@@ -225,6 +225,40 @@ export class ApiClient {
 		);
 	}
 
+	// ==================== TEST SUITES ====================
+
+	/**
+	 * List test suites for a project
+	 */
+	async listSuites(
+		projectId: string,
+		params?: { parentId?: string }
+	): Promise<APIResponse> {
+		const searchParams = new URLSearchParams();
+		if (params?.parentId) {
+			searchParams.set('parentId', params.parentId);
+		}
+
+		const url = `${this.baseURL}/api/projects/${projectId}/suites${
+			searchParams.toString() ? '?' + searchParams.toString() : ''
+		}`;
+		return await this.request.get(url, {
+			headers: this.getHeaders()
+		});
+	}
+
+	/**
+	 * Delete a test suite
+	 */
+	async deleteSuite(projectId: string, suiteId: string): Promise<APIResponse> {
+		return await this.request.delete(
+			`${this.baseURL}/api/projects/${projectId}/suites/${suiteId}`,
+			{
+				headers: this.getHeaders()
+			}
+		);
+	}
+
 	// ==================== TEST RUNS ====================
 
 	/**

--- a/e2e/pages/test-cases.ts
+++ b/e2e/pages/test-cases.ts
@@ -1,4 +1,4 @@
-import { Page, Locator } from '@playwright/test';
+import { Page, Locator, expect } from '@playwright/test';
 import { BasePage } from './base';
 
 /**
@@ -143,21 +143,31 @@ export class TestCasesPage extends BasePage {
 	}
 
 	/**
+	 * Ensure the uncategorized suite section is expanded in the main content area
+	 */
+	async ensureUncategorizedExpanded() {
+		const uncategorizedButton = this.testSuitesContainer.locator(
+			'button:has-text("Uncategorized")'
+		);
+		if (!(await this.isVisible(uncategorizedButton))) {
+			return;
+		}
+
+		const uncategorizedHeading = this.testCasesMain.locator('h3:has-text("Uncategorized")');
+		if (!(await this.isVisible(uncategorizedHeading))) {
+			await this.click(uncategorizedButton);
+			await uncategorizedHeading.waitFor({ state: 'visible', timeout: 5000 });
+		}
+	}
+
+	/**
 	 * Create a new test case
 	 * @param title - Test case title
 	 * @param description - Optional test case description
 	 * @param waitForCreation - Whether to wait for creation to complete
 	 */
 	async createTestCase(title: string, description?: string, waitForCreation = true) {
-		// Make sure we're in the uncategorized section by clicking it if needed
-		const uncategorizedButton = this.testSuitesContainer.locator(
-			'button:has-text("Uncategorized")'
-		);
-		if (await this.isVisible(uncategorizedButton)) {
-			// Click to ensure it's expanded
-			await this.click(uncategorizedButton);
-			await this.page.waitForTimeout(500);
-		}
+		await this.ensureUncategorizedExpanded();
 
 		// Click new test case button if form isn't visible
 		if (!(await this.isVisible(this.newTestCaseTitleInput))) {
@@ -180,10 +190,30 @@ export class TestCasesPage extends BasePage {
 			await this.pressKey('Enter');
 		}
 
-		// Wait for creation to complete
 		if (waitForCreation) {
-			await this.page.waitForTimeout(2000); // Increased timeout for optimistic rendering
+			await this.waitForTestCasePersisted(title);
 		}
+	}
+
+	/**
+	 * Wait until the test case exists with a real (non-temporary) server ID
+	 */
+	async waitForTestCasePersisted(title: string, timeout = 20000) {
+		await this.waitForTestCase(title);
+
+		const testCaseRow = this.page.locator('[data-testcase-id]').filter({
+			has: this.page.locator('[data-test="test-case-button"]').filter({ hasText: title })
+		}).first();
+
+		await expect
+			.poll(
+				async () => {
+					const id = await testCaseRow.getAttribute('data-testcase-id');
+					return Boolean(id && !id.startsWith('temp-'));
+				},
+				{ timeout, message: `Timed out waiting for "${title}" to persist` }
+			)
+			.toBe(true);
 	}
 
 	/**
@@ -216,7 +246,8 @@ export class TestCasesPage extends BasePage {
 		// Click the test case button containing the specific title
 		// Use force: true to bypass actionability checks that might interfere with draggable elements
 		const testCaseButton = this.page
-			.locator(`[data-test="test-case-button"]:has-text("${title}")`)
+			.locator('[data-test="test-case-button"]')
+			.filter({ hasText: title })
 			.first();
 		await testCaseButton.click({ force: true });
 		// Wait for the modal to appear
@@ -384,18 +415,24 @@ export class TestCasesPage extends BasePage {
 	/**
 	 * Wait for test case to appear in the list
 	 */
-	async waitForTestCase(title: string, timeout = 10000) {
-		// First ensure the uncategorized section is expanded
-		const uncategorizedButton = this.testSuitesContainer.locator(
-			'button:has-text("Uncategorized")'
-		);
-		if (await this.isVisible(uncategorizedButton)) {
-			await this.click(uncategorizedButton);
-			await this.page.waitForTimeout(500);
-		}
+	async waitForTestCase(title: string, timeout = 15000) {
+		await this.ensureUncategorizedExpanded();
 
-		// Now wait for the test case to appear
-		await this.page.waitForSelector(`text="${title}"`, { timeout, state: 'visible' });
+		const testCaseButton = this.page
+			.locator('[data-test="test-case-button"]')
+			.filter({ hasText: title })
+			.first();
+
+		await testCaseButton.scrollIntoViewIfNeeded();
+		await testCaseButton.waitFor({ state: 'visible', timeout });
+	}
+
+	/**
+	 * Reload the page and wait for it to be ready (updates server-derived stats)
+	 */
+	async reloadAndWait() {
+		await this.page.reload({ waitUntil: 'networkidle' });
+		await this.waitForLoad();
 	}
 
 	/**

--- a/e2e/pages/test-cases.ts
+++ b/e2e/pages/test-cases.ts
@@ -201,9 +201,12 @@ export class TestCasesPage extends BasePage {
 	async waitForTestCasePersisted(title: string, timeout = 20000) {
 		await this.waitForTestCase(title);
 
-		const testCaseRow = this.page.locator('[data-testcase-id]').filter({
-			has: this.page.locator('[data-test="test-case-button"]').filter({ hasText: title })
-		}).first();
+		const testCaseRow = this.page
+			.locator('[data-testcase-id]')
+			.filter({
+				has: this.page.locator('[data-test="test-case-button"]').filter({ hasText: title })
+			})
+			.first();
 
 		await expect
 			.poll(

--- a/e2e/tests/test-cases.test.ts
+++ b/e2e/tests/test-cases.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { TestCasesPage } from '../pages/test-cases';
 import { loginAsTestUser } from '../helpers/auth';
+import { cleanupE2eTestData, getE2eProjectId } from '../helpers/cleanup';
 
 /**
  * Test Cases Page E2E Tests
@@ -12,33 +13,26 @@ import { loginAsTestUser } from '../helpers/auth';
  */
 
 test.describe('Test Cases Page', () => {
+	test.describe.configure({ mode: 'serial' });
+
 	let testCasesPage: TestCasesPage;
 	let projectId: string;
 
+	test.beforeAll(async ({ request }) => {
+		projectId = getE2eProjectId();
+		await cleanupE2eTestData(request, projectId);
+	});
+
+	test.afterEach(async ({ request }) => {
+		if (projectId) {
+			await cleanupE2eTestData(request, projectId);
+		}
+	});
+
 	test.beforeEach(async ({ page }) => {
-		// Login before each test
+		projectId = getE2eProjectId();
 		await loginAsTestUser(page);
 
-		// Get the first project from the projects page
-		// Wait for projects to load (look for project cards with links)
-		await page.waitForSelector('a[href*="/projects/"]', { timeout: 10000 });
-
-		// Get first project link (they link to /projects/[id]/runs)
-		const firstProjectLink = page.locator('a[href*="/projects/"][href*="/runs"]').first();
-		const href = await firstProjectLink.getAttribute('href');
-
-		if (!href) {
-			throw new Error('No project found. Please create a project first.');
-		}
-
-		// Extract project ID from href (format: /projects/[id]/runs)
-		const match = href.match(/\/projects\/([^/]+)\/runs/);
-		if (!match) {
-			throw new Error('Could not extract project ID from URL');
-		}
-		projectId = match[1];
-
-		// Initialize page object and navigate
 		testCasesPage = new TestCasesPage(page, projectId);
 		await testCasesPage.navigate();
 		await testCasesPage.waitForLoad();
@@ -130,6 +124,7 @@ test.describe('Test Cases Page', () => {
 	});
 
 	test.describe('Test Case Management', () => {
+		test.describe.configure({ timeout: 60_000 });
 		test('should display "Test Cases" main section', async () => {
 			await testCasesPage.assertVisible(testCasesPage.testCasesMain);
 			await testCasesPage.assertVisible(testCasesPage.testCasesHeader);
@@ -200,75 +195,52 @@ test.describe('Test Cases Page', () => {
 			await testCasesPage.assertVisible(testCasesPage.newTestCaseTitleInput);
 		});
 
-		test('should increment test case count after creating a test case', async ({ page }) => {
+		test('should increment test case count after creating a test case', async () => {
 			const initialStats = await testCasesPage.getStats();
 			const testCaseTitle = `E2E Count Test ${Date.now()}`;
 
 			await testCasesPage.createTestCase(testCaseTitle);
-			await testCasesPage.waitForTestCase(testCaseTitle);
+			await testCasesPage.reloadAndWait();
 
-			// Refresh stats
-			await page.waitForTimeout(1000);
 			const updatedStats = await testCasesPage.getStats();
-
 			expect(updatedStats.totalTestCases).toBe(initialStats.totalTestCases + 1);
 		});
 	});
 
 	test.describe('Test Case Modal', () => {
-		test('should open modal when clicking on a test case', async ({ page }) => {
-			// First, create a test case to click on
+		test.describe.configure({ timeout: 60_000 });
+		test('should open modal when clicking on a test case', async () => {
 			const testCaseTitle = `E2E Modal Test ${Date.now()}`;
 			await testCasesPage.createTestCase(testCaseTitle);
-			await testCasesPage.waitForTestCase(testCaseTitle);
-
-			// Click on the test case
 			await testCasesPage.clickTestCase(testCaseTitle);
-
-			// Wait for modal to appear
-			await page.waitForTimeout(500);
-
-			// Verify modal is visible
 			expect(await testCasesPage.isModalVisible()).toBe(true);
 		});
 
-		test('should display test case information in modal', async ({ page }) => {
+		test('should display test case information in modal', async () => {
 			const testCaseTitle = `E2E Modal Info Test ${Date.now()}`;
 			await testCasesPage.createTestCase(testCaseTitle);
-			await testCasesPage.waitForTestCase(testCaseTitle);
-
 			await testCasesPage.clickTestCase(testCaseTitle);
-			await page.waitForTimeout(500);
 
 			const modalInfo = await testCasesPage.getModalTestCaseInfo();
 			expect(modalInfo).not.toBeNull();
 			expect(modalInfo?.title).toContain(testCaseTitle);
 		});
 
-		test('should close modal when clicking close button', async ({ page }) => {
+		test('should close modal when clicking close button', async () => {
 			const testCaseTitle = `E2E Modal Close Test ${Date.now()}`;
 			await testCasesPage.createTestCase(testCaseTitle);
-			await testCasesPage.waitForTestCase(testCaseTitle);
-
 			await testCasesPage.clickTestCase(testCaseTitle);
-			await page.waitForTimeout(500);
 
 			expect(await testCasesPage.isModalVisible()).toBe(true);
 
 			await testCasesPage.closeModal();
-			await page.waitForTimeout(500);
-
-			expect(await testCasesPage.isModalVisible()).toBe(false);
+			await expect(testCasesPage.testCaseModal).toBeHidden({ timeout: 5000 });
 		});
 
-		test('should have "Open Full View" button in modal', async ({ page }) => {
+		test('should have "Open Full View" button in modal', async () => {
 			const testCaseTitle = `E2E Full View Test ${Date.now()}`;
 			await testCasesPage.createTestCase(testCaseTitle);
-			await testCasesPage.waitForTestCase(testCaseTitle);
-
 			await testCasesPage.clickTestCase(testCaseTitle);
-			await page.waitForTimeout(500);
-
 			await testCasesPage.assertVisible(testCasesPage.modalOpenFullViewButton);
 		});
 
@@ -277,22 +249,18 @@ test.describe('Test Cases Page', () => {
 		}) => {
 			const testCaseTitle = `E2E Navigation Test ${Date.now()}`;
 			await testCasesPage.createTestCase(testCaseTitle);
-			await testCasesPage.waitForTestCase(testCaseTitle);
-
 			await testCasesPage.clickTestCase(testCaseTitle);
-			await page.waitForTimeout(500);
 
-			await testCasesPage.openFullView();
-
-			// Wait for navigation
-			await page.waitForURL(`**/projects/${projectId}/cases/**`, { timeout: 5000 });
-
-			// Verify we're on the test case detail page
+			await Promise.all([
+				page.waitForURL(`**/projects/${projectId}/cases/**`, { timeout: 15000 }),
+				testCasesPage.openFullView()
+			]);
 			expect(page.url()).toMatch(/\/projects\/[^/]+\/cases\/[^/]+/);
 		});
 	});
 
 	test.describe('Suite and Test Case Integration', () => {
+		test.describe.configure({ timeout: 60_000 });
 		test('should create suite and add test case to it', async ({ page }) => {
 			const suiteName = `E2E Integration Suite ${Date.now()}`;
 			const testCaseTitle = `E2E Integration TC ${Date.now()}`;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,13 +13,18 @@ function stripAnsi(str: string): string {
 	return str.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').replace(/\[\d+m/g, '');
 }
 
+const baseURL = stripAnsi(process.env.BASE_URL || process.env.PUBLIC_BASE_URL || '');
+if (!baseURL) {
+	throw new Error('BASE_URL or PUBLIC_BASE_URL must be set for Playwright E2E tests');
+}
+
 export default defineConfig({
 	reporter: [
 		['list'],
 		[
 			'@qastudio-dev/playwright',
 			{
-				apiUrl: stripAnsi('https://qastudio.dev/api'),
+				apiUrl: stripAnsi(`${baseURL.replace(/\/$/, '')}/api`),
 				apiKey: stripAnsi(process.env.QA_STUDIO_API_KEY),
 				projectId: stripAnsi(process.env.QA_STUDIO_PROJECT_ID),
 				environment: process.env.CI ? 'CI' : 'local',
@@ -28,7 +33,7 @@ export default defineConfig({
 		]
 	],
 	use: {
-		baseURL: 'https://qastudio.dev',
+		baseURL,
 		// Capture screenshots on failure
 		screenshot: 'only-on-failure',
 		// Capture videos on failure


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the five failing Playwright tests in `e2e/tests/test-cases.test.ts` from [CI run #26692692991](https://github.com/QAStudio-Dev/studio/actions/runs/26692692991).

## Root cause

The test-cases suite was hitting a shared production project with:

- **No cleanup** of `E2E …` test cases and suites left from prior runs (polluting lists and slowing the UI)
- **Parallel workers** (4) mutating the same project concurrently
- **Fragile waits** (`text=…` selectors, fixed sleeps) and stats read before server reload
- **Modal navigation** using optimistic `temp-*` IDs before the API persisted the real case ID

## Changes

- **`e2e/helpers/cleanup.ts`**: delete `E2E`-prefixed cases/suites via API in `beforeAll` and `afterEach`
- **`test-cases.test.ts`**: serial execution, use `QA_STUDIO_PROJECT_ID`, longer timeouts for mutation tests
- **`test-cases` page object**: expand uncategorized reliably, wait for persisted IDs, reload for stats, safer locators
- **`api.ts`**: `listSuites` / `deleteSuite` for cleanup
- **`playwright.config.ts`**: read `baseURL` from `BASE_URL` or `PUBLIC_BASE_URL` (matches CI workflow)

## Verification

Ran locally against production:

```
32 tests — 26 passed, 6 skipped (intentionally), 0 failed
```

Previously failing tests (count increment, modal open/info/close, Open Full View navigation) all pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df8754bc-f14f-4d3c-bfed-e90c3aa75428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df8754bc-f14f-4d3c-bfed-e90c3aa75428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

