### PR TITLE
fix(e2e): update home hero description selector

### DIFF
--- a/e2e/pages/home.ts
+++ b/e2e/pages/home.ts
@@ -27,7 +27,8 @@ export class HomePage extends BasePage {
 		this.logo = page.locator('img[alt="QA Studio"]').first();
 		this.signInButton = page.locator('a[href="/login"]');
 		this.heroTitle = page.locator('h1').first();
-		this.heroDescription = page.locator('p.text-xl').first();
+		// Hero subheading uses responsive typography (text-lg sm:text-xl), not bare text-xl
+		this.heroDescription = page.locator('main h1 + p').first();
 		this.getStartedButton = page.getByRole('link', { name: /get started/i });
 		this.viewDocsButton = page.getByRole('link', { name: /view docs|documentation/i });
 		this.discordLink = page.locator('a[href*="discord"]');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the failing Playwright test **"should display hero section with title and description"** by updating the `HomePage` hero description locator.

## Problem

The page object used `p.text-xl`, but the home hero subheading was updated to use responsive typography:

```svelte
<p class="mb-10 text-lg leading-relaxed text-white/90 sm:text-xl ...">
```

There is no element with a bare `text-xl` class, so Playwright reported **element(s) not found**.

## Solution

Target the hero subheading structurally as the paragraph immediately following the main hero `h1`:

```ts
this.heroDescription = page.locator('main h1 + p').first();
```

This stays stable across responsive class changes while still asserting the hero description is visible.

## Testing

- [ ] CI E2E: `e2e/tests/home.test.ts` — hero section test
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07b87919-e10b-4683-aef0-b38a960bb24f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07b87919-e10b-4683-aef0-b38a960bb24f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

