### PR TITLE
fix: resolve 500 error when opening test cases with execution history

### DIFF
--- a/src/__tests__/lib/server/test-result-steps-select.test.ts
+++ b/src/__tests__/lib/server/test-result-steps-select.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { testResultStepsSelect } from '$lib/server/test-result-steps-select';
+
+const VALID_TEST_STEP_RESULT_FIELDS = new Set([
+	'id',
+	'stepNumber',
+	'title',
+	'category',
+	'status',
+	'duration',
+	'error',
+	'stackTrace',
+	'startTime',
+	'location',
+	'comment',
+	'parentStepId',
+	'testResultId',
+	'createdAt',
+	'childSteps'
+]);
+
+const REMOVED_FIELDS = ['description', 'errorMessage'];
+
+function collectSelectKeys(select: Record<string, unknown>): string[] {
+	return Object.keys(select).filter((key) => key !== 'childSteps');
+}
+
+describe('testResultStepsSelect', () => {
+	it('uses current TestStepResult field names', () => {
+		const parentKeys = collectSelectKeys(testResultStepsSelect.select);
+		const childKeys = collectSelectKeys(testResultStepsSelect.select.childSteps.select);
+
+		for (const key of [...parentKeys, ...childKeys]) {
+			expect(VALID_TEST_STEP_RESULT_FIELDS.has(key)).toBe(true);
+		}
+
+		expect(parentKeys).toContain('title');
+		expect(parentKeys).toContain('error');
+		expect(parentKeys).toContain('category');
+	});
+
+	it('does not use removed schema field names', () => {
+		const parentKeys = collectSelectKeys(testResultStepsSelect.select);
+		const childKeys = collectSelectKeys(testResultStepsSelect.select.childSteps.select);
+
+		for (const key of [...parentKeys, ...childKeys]) {
+			expect(REMOVED_FIELDS).not.toContain(key);
+		}
+	});
+
+	it('limits nested step depth to one child level', () => {
+		expect(testResultStepsSelect.select.childSteps.select).not.toHaveProperty('childSteps');
+	});
+});

--- a/src/lib/server/test-result-steps-select.ts
+++ b/src/lib/server/test-result-steps-select.ts
@@ -1,6 +1,8 @@
 /**
  * Nested step depth for Prisma. TestStepsViewer renders one child level only.
  */
+import type { Prisma } from '$prisma/client';
+
 export const testResultStepsInclude = {
 	where: { parentStepId: null },
 	orderBy: { stepNumber: 'asc' as const },
@@ -19,7 +21,7 @@ const testStepFieldsSelect = {
 	status: true,
 	duration: true,
 	error: true
-} as const;
+} satisfies Prisma.TestStepResultSelect;
 
 export const testResultStepsSelect = {
 	where: { parentStepId: null },

--- a/src/lib/server/test-result-steps-select.ts
+++ b/src/lib/server/test-result-steps-select.ts
@@ -11,26 +11,24 @@ export const testResultStepsInclude = {
 	}
 } as const;
 
+const testStepFieldsSelect = {
+	id: true,
+	stepNumber: true,
+	title: true,
+	category: true,
+	status: true,
+	duration: true,
+	error: true
+} as const;
+
 export const testResultStepsSelect = {
 	where: { parentStepId: null },
 	orderBy: { stepNumber: 'asc' as const },
 	select: {
-		id: true,
-		stepNumber: true,
-		description: true,
-		status: true,
-		duration: true,
-		errorMessage: true,
+		...testStepFieldsSelect,
 		childSteps: {
 			orderBy: { stepNumber: 'asc' as const },
-			select: {
-				id: true,
-				stepNumber: true,
-				description: true,
-				status: true,
-				duration: true,
-				errorMessage: true
-			}
+			select: testStepFieldsSelect
 		}
 	}
 } as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the production 500 error reported when opening or saving test cases on case detail pages (e.g. `/projects/jZtag3TH/cases/tUth`).

A recent performance refactor introduced a slim Prisma select for execution step history using stale field names (`description`, `errorMessage`). The `TestStepResult` model uses `title` and `error`, so Prisma throws when loading cases that have execution results with steps.

## Changes

- Correct `testResultStepsSelect` field names in `src/lib/server/test-result-steps-select.ts` (`title`, `error`, `category`)
- Add regression test in `src/__tests__/lib/server/test-result-steps-select.test.ts`

## Test plan

- [x] `npm run format`
- [x] `npm run check`
- [x] `npm run test:unit -- --run src/__tests__/lib/server/test-result-steps-select.test.ts`
- [ ] Deploy to staging/production and verify opening a case with execution history no longer returns 500
- [ ] Verify editing and saving a case reloads without 500
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3ce2-93ff-79de-bceb-34e6a6b568b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3ce2-93ff-79de-bceb-34e6a6b568b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated result step selection so displayed fields use the current schema: step `title` and `error` are returned instead of outdated names.
  * Ensured nested `childSteps` selection is restricted to a single level to avoid extra nesting.
* **Tests**
  * Added a new test suite validating the generated step select clause, including correct field inclusion/exclusion and one-level `childSteps` nesting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->