### PR TITLE
fix(e2e): avoid scanning all test cases on shared E2E project

### DIFF
--- a/e2e/pages/test-cases.ts
+++ b/e2e/pages/test-cases.ts
@@ -161,12 +161,38 @@ export class TestCasesPage extends BasePage {
 	}
 
 	/**
+	 * Look up a single test case by title without scanning the entire list.
+	 * The shared E2E project can contain hundreds of cases, so avoid getTestCases().
+	 */
+	async getTestCaseByTitle(title: string): Promise<{ title: string; id: string }> {
+		await this.ensureUncategorizedExpanded();
+
+		const testCaseRow = this.page
+			.locator('[data-testcase-id]')
+			.filter({
+				has: this.page.locator('[data-test="test-case-button"]').filter({ hasText: title })
+			})
+			.first();
+
+		const id = await testCaseRow.getAttribute('data-testcase-id');
+		if (!id) {
+			throw new Error(`Test case "${title}" not found`);
+		}
+
+		return { title, id };
+	}
+
+	/**
 	 * Create a new test case
 	 * @param title - Test case title
 	 * @param description - Optional test case description
 	 * @param waitForCreation - Whether to wait for creation to complete
 	 */
-	async createTestCase(title: string, description?: string, waitForCreation = true) {
+	async createTestCase(
+		title: string,
+		description?: string,
+		waitForCreation = true
+	): Promise<{ title: string; id: string } | void> {
 		await this.ensureUncategorizedExpanded();
 
 		// Click new test case button if form isn't visible
@@ -202,6 +228,7 @@ export class TestCasesPage extends BasePage {
 			const createResponse = await createResponsePromise;
 			expect(createResponse.ok()).toBe(true);
 			await this.waitForTestCasePersisted(title);
+			return this.getTestCaseByTitle(title);
 		}
 	}
 

--- a/e2e/pages/test-cases.ts
+++ b/e2e/pages/test-cases.ts
@@ -161,19 +161,27 @@ export class TestCasesPage extends BasePage {
 	}
 
 	/**
+	 * Locate the test case row for an exact title match (avoids substring collisions).
+	 */
+	private testCaseRowByTitle(title: string): Locator {
+		return this.page
+			.locator('[data-testcase-id]')
+			.filter({
+				has: this.page
+					.locator('[data-test="test-case-button"]')
+					.getByText(title, { exact: true })
+			})
+			.first();
+	}
+
+	/**
 	 * Look up a single test case by title without scanning the entire list.
 	 * The shared E2E project can contain hundreds of cases, so avoid getTestCases().
 	 */
 	async getTestCaseByTitle(title: string): Promise<{ title: string; id: string }> {
 		await this.ensureUncategorizedExpanded();
 
-		const testCaseRow = this.page
-			.locator('[data-testcase-id]')
-			.filter({
-				has: this.page.locator('[data-test="test-case-button"]').filter({ hasText: title })
-			})
-			.first();
-
+		const testCaseRow = this.testCaseRowByTitle(title);
 		const id = await testCaseRow.getAttribute('data-testcase-id');
 		if (!id) {
 			throw new Error(`Test case "${title}" not found`);
@@ -227,33 +235,40 @@ export class TestCasesPage extends BasePage {
 		if (waitForCreation) {
 			const createResponse = await createResponsePromise;
 			expect(createResponse.ok()).toBe(true);
-			await this.waitForTestCasePersisted(title);
-			return this.getTestCaseByTitle(title);
+			return this.waitForTestCasePersisted(title);
 		}
 	}
 
 	/**
 	 * Wait until the test case exists with a real (non-temporary) server ID
 	 */
-	async waitForTestCasePersisted(title: string, timeout = 30000) {
-		await this.waitForTestCase(title);
+	async waitForTestCasePersisted(
+		title: string,
+		timeout = 30000
+	): Promise<{ title: string; id: string }> {
+		await this.ensureUncategorizedExpanded();
 
-		const testCaseRow = this.page
-			.locator('[data-testcase-id]')
-			.filter({
-				has: this.page.locator('[data-test="test-case-button"]').filter({ hasText: title })
-			})
-			.first();
+		const testCaseRow = this.testCaseRowByTitle(title);
+		const testCaseButton = testCaseRow.locator('[data-test="test-case-button"]');
+		await testCaseButton.scrollIntoViewIfNeeded();
+		await testCaseButton.waitFor({ state: 'visible', timeout: Math.min(timeout, 15000) });
 
+		let persistedId = '';
 		await expect
 			.poll(
 				async () => {
 					const id = await testCaseRow.getAttribute('data-testcase-id');
-					return Boolean(id && !id.startsWith('temp-'));
+					if (id && !id.startsWith('temp-')) {
+						persistedId = id;
+						return true;
+					}
+					return false;
 				},
 				{ timeout, message: `Timed out waiting for "${title}" to persist` }
 			)
 			.toBe(true);
+
+		return { title, id: persistedId };
 	}
 
 	/**

--- a/e2e/tests/test-case-detail.test.ts
+++ b/e2e/tests/test-case-detail.test.ts
@@ -38,10 +38,7 @@ test.describe('Test Case Detail Page', () => {
 			const listPage = new TestCasesPage(page, projectId);
 			await listPage.navigate();
 			await listPage.waitForLoad();
-			await listPage.createTestCase(title);
-
-			const testCases = await listPage.getTestCases();
-			const created = testCases.find((tc) => tc.title === title);
+			const created = await listPage.createTestCase(title);
 			expect(created).toBeDefined();
 			expect(created?.id).toBeTruthy();
 			expect(created?.id.startsWith('temp-')).toBe(false);
@@ -87,10 +84,7 @@ test.describe('Test Case Detail Page', () => {
 			const listPage = new TestCasesPage(page, projectId);
 			await listPage.navigate();
 			await listPage.waitForLoad();
-			await listPage.createTestCase(originalTitle);
-
-			const testCases = await listPage.getTestCases();
-			const created = testCases.find((tc) => tc.title === originalTitle);
+			const created = await listPage.createTestCase(originalTitle);
 			expect(created).toBeDefined();
 
 			const detailPage = new TestCaseDetailPage(page, projectId, created!.id);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Playwright CI run [#821](https://github.com/QAStudio-Dev/studio/actions/runs/28881637212) failed after merging the test-case-detail E2E tests.

The failing test (`should open a newly created test case without a server error`) timed out in `TestCasesPage.getTestCases()` while iterating `[data-testcase-id]` elements. The shared production E2E project has accumulated 240+ test cases, so scanning the full list exceeds the 60s test timeout.

## Fix

- Add `getTestCaseByTitle()` for a targeted lookup by title instead of scanning the entire page
- Return the created test case from `createTestCase()` after persistence
- Update `test-case-detail.test.ts` to use the returned case instead of `getTestCases().find(...)`

## Verification

- `npm run format`
- `npm run check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfb2a74c-9624-4eaa-ad26-b270b1c6475f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfb2a74c-9624-4eaa-ad26-b270b1c6475f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved test case page helpers to retrieve a specific test case directly by title.
  * Test case creation can now return the newly created test case’s title and ID when creation is complete.

* **Bug Fixes**
  * Updated end-to-end tests to use the created test case’s returned ID for more reliable navigation to the detail page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->