### PR TITLE
Set up dev environment + note DB must not be reset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ Use **tmux** (`tmux -f /exec-daemon/tmux.portal.conf`) for `npm run dev` and oth
 
 ### Gotchas
 
+- **Do not reset the DB tables.** The `DATABASE_URL` points at a shared, already-provisioned Postgres (Neon) whose schema is up to date (`npx prisma migrate status` reports "up to date"). Never run `prisma migrate reset` / `prisma db push --force-reset` or otherwise drop/recreate tables; use `npx prisma migrate deploy` only if new migrations need applying. Creating rows (e.g. a test signup/project) is fine.
 - `postinstall` runs `prisma generate` but may skip if `.svelte-kit` is missing; run `npx svelte-kit sync` first on a clean clone.
 - Lint reports many `svelte/no-navigation-without-resolve` issues repo-wide; do not treat as introduced by your change unless you touched those files.
 - Default `npm run test:e2e` does **not** start a local server.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Verified the QA Studio development environment end-to-end and added a durable note (per user request) that the shared DB must not be reset during setup.

The only code change is a one-line addition to `AGENTS.md`. Environment setup was validated but required no source changes — the repo's existing tooling works as documented.

## Environment verification

- `npm install` — clean/idempotent
- `npm run check` — 0 errors (34 pre-existing warnings)
- `npm run test:unit -- --run` — 681 passed, 5 todo
- `npm run build` — succeeds (adapter-vercel)
- `npm run dev` — serves on port 3000 (HTTP 200)
- `npx prisma migrate status` — "Database schema is up to date" (no reset needed)

## Hello-world flow

Signed up a new account, completed onboarding (team + Free plan), and created a project ("Demo Project"), landing on its overview page — no errors.

[qa_studio_signup_create_project.mp4](https://cursor.com/agents/bc-54bdbf30-c238-49b2-8db8-c9403f9697dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fqa_studio_signup_create_project.mp4)

[Demo Project created](https://cursor.com/agents/bc-54bdbf30-c238-49b2-8db8-c9403f9697dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_project_created.webp)

## Note

Per user instruction, do not reset/drop DB tables (`DATABASE_URL` is a shared, already-migrated Neon Postgres). Captured in `AGENTS.md` gotchas.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54bdbf30-c238-49b2-8db8-c9403f9697dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54bdbf30-c238-49b2-8db8-c9403f9697dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new safety note about handling the shared Postgres schema, including guidance to avoid destructive reset commands and to apply migrations only when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->