### PR TITLE
fix(e2e): scope cleanup by test file to prevent parallel race

### DIFF
--- a/e2e/helpers/cleanup.ts
+++ b/e2e/helpers/cleanup.ts
@@ -1,8 +1,19 @@
 import type { APIRequestContext } from '@playwright/test';
 import { ApiClient } from '../pages/api';
 
-/** Prefix used by test-cases E2E tests for created resources */
+/** Prefix for test-cases.test.ts resources (must not overlap with other E2E files). */
+export const E2E_CASES_PREFIX = 'E2E Cases';
+
+/** Prefix for test-case-detail.test.ts resources (must not overlap with other E2E files). */
+export const E2E_DETAIL_PREFIX = 'E2E Detail';
+
+/** @deprecated Use E2E_CASES_PREFIX or E2E_DETAIL_PREFIX for scoped cleanup. */
 export const E2E_RESOURCE_PREFIX = 'E2E ';
+
+export type CleanupE2eOptions = {
+	/** Only delete cases/suites whose title/name starts with this prefix. */
+	prefix: string;
+};
 
 export function getApiClient(request: APIRequestContext): ApiClient {
 	const apiKey = process.env.QA_STUDIO_API_KEY;
@@ -20,8 +31,8 @@ export function getE2eProjectId(): string {
 	return projectId;
 }
 
-function isE2eResourceName(name: string): boolean {
-	return name.startsWith(E2E_RESOURCE_PREFIX) || name.startsWith('E2E');
+function matchesCleanupPrefix(name: string, prefix: string): boolean {
+	return name.startsWith(prefix);
 }
 
 type SuiteNode = {
@@ -50,8 +61,10 @@ function flattenSuites(
  */
 export async function cleanupE2eTestData(
 	request: APIRequestContext,
-	projectId: string
+	projectId: string,
+	options: CleanupE2eOptions
 ): Promise<{ casesDeleted: number; suitesDeleted: number }> {
+	const { prefix } = options;
 	const api = getApiClient(request);
 	let casesDeleted = 0;
 	let suitesDeleted = 0;
@@ -61,7 +74,7 @@ export async function cleanupE2eTestData(
 
 	while (hasMore) {
 		const response = await api.listTestCases(projectId, {
-			search: 'E2E',
+			search: prefix,
 			page,
 			limit: 100
 		});
@@ -78,7 +91,7 @@ export async function cleanupE2eTestData(
 		}
 
 		for (const testCase of cases) {
-			if (!isE2eResourceName(testCase.title)) {
+			if (!matchesCleanupPrefix(testCase.title, prefix)) {
 				continue;
 			}
 			const deleted = await api.deleteTestCase(projectId, testCase.id);
@@ -95,7 +108,7 @@ export async function cleanupE2eTestData(
 	if (suitesResponse.ok()) {
 		const suites = (await api.getResponseBody(suitesResponse)) as SuiteNode[];
 		const e2eSuites = flattenSuites(suites)
-			.filter((suite) => isE2eResourceName(suite.name))
+			.filter((suite) => matchesCleanupPrefix(suite.name, prefix))
 			.sort((a, b) => b.depth - a.depth);
 
 		for (const suite of e2eSuites) {
@@ -113,4 +126,28 @@ export async function cleanupE2eTestData(
 	}
 
 	return { casesDeleted, suitesDeleted };
+}
+
+/**
+ * Poll the API until a test case is readable (avoids navigating before persistence
+ * or while another worker's cleanup is in flight).
+ */
+export async function waitForTestCaseInApi(
+	request: APIRequestContext,
+	projectId: string,
+	testCaseId: string,
+	timeoutMs = 30_000
+): Promise<void> {
+	const api = getApiClient(request);
+	const deadline = Date.now() + timeoutMs;
+
+	while (Date.now() < deadline) {
+		const response = await api.getTestCase(projectId, testCaseId);
+		if (response.ok()) {
+			return;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 250));
+	}
+
+	throw new Error(`Timed out waiting for test case ${testCaseId} to be available via API`);
 }

--- a/e2e/helpers/cleanup.ts
+++ b/e2e/helpers/cleanup.ts
@@ -142,9 +142,13 @@ export async function waitForTestCaseInApi(
 	const deadline = Date.now() + timeoutMs;
 
 	while (Date.now() < deadline) {
-		const response = await api.getTestCase(projectId, testCaseId);
-		if (response.ok()) {
-			return;
+		try {
+			const response = await api.getTestCase(projectId, testCaseId);
+			if (response.ok()) {
+				return;
+			}
+		} catch {
+			// Transient network/request errors — keep polling until deadline.
 		}
 		await new Promise((resolve) => setTimeout(resolve, 250));
 	}

--- a/e2e/helpers/test-case-fixtures.ts
+++ b/e2e/helpers/test-case-fixtures.ts
@@ -70,7 +70,7 @@ export async function createTestCaseWithExecutionHistory(
 
 	const runResponse = await api.createTestRun({
 		projectId,
-		name: `E2E Run ${Date.now()}`
+		name: `E2E Detail Run ${Date.now()}`
 	});
 	expect(runResponse.ok()).toBe(true);
 	const runBody = await api.getResponseBody(runResponse);

--- a/e2e/tests/test-case-detail.test.ts
+++ b/e2e/tests/test-case-detail.test.ts
@@ -2,7 +2,12 @@ import { test, expect } from '@playwright/test';
 import { TestCasesPage } from '../pages/test-cases';
 import { TestCaseDetailPage } from '../pages/test-case-detail';
 import { loginAsTestUser } from '../helpers/auth';
-import { cleanupE2eTestData, getE2eProjectId } from '../helpers/cleanup';
+import {
+	cleanupE2eTestData,
+	E2E_DETAIL_PREFIX,
+	getE2eProjectId,
+	waitForTestCaseInApi
+} from '../helpers/cleanup';
 import { createTestCaseWithExecutionHistory } from '../helpers/test-case-fixtures';
 
 /**
@@ -18,20 +23,23 @@ test.describe('Test Case Detail Page', () => {
 
 	test.beforeAll(async ({ request }) => {
 		projectId = getE2eProjectId();
-		await cleanupE2eTestData(request, projectId);
+		await cleanupE2eTestData(request, projectId, { prefix: E2E_DETAIL_PREFIX });
 	});
 
 	test.afterEach(async ({ request }) => {
 		if (projectId) {
-			await cleanupE2eTestData(request, projectId);
+			await cleanupE2eTestData(request, projectId, { prefix: E2E_DETAIL_PREFIX });
 		}
 	});
 
 	test.describe('Open test case', () => {
 		test.describe.configure({ timeout: 60_000 });
 
-		test('should open a newly created test case without a server error', async ({ page }) => {
-			const title = `E2E Open Case ${Date.now()}`;
+		test('should open a newly created test case without a server error', async ({
+			page,
+			request
+		}) => {
+			const title = `E2E Detail Open ${Date.now()}`;
 
 			await loginAsTestUser(page);
 
@@ -42,6 +50,8 @@ test.describe('Test Case Detail Page', () => {
 			expect(created).toBeDefined();
 			expect(created?.id).toBeTruthy();
 			expect(created?.id.startsWith('temp-')).toBe(false);
+
+			await waitForTestCaseInApi(request, projectId, created!.id);
 
 			const detailPage = new TestCaseDetailPage(page, projectId, created!.id);
 			await detailPage.navigate();
@@ -55,7 +65,7 @@ test.describe('Test Case Detail Page', () => {
 			page,
 			request
 		}) => {
-			const title = `E2E History Case ${Date.now()}`;
+			const title = `E2E Detail History ${Date.now()}`;
 			const fixture = await createTestCaseWithExecutionHistory(request, projectId, title);
 
 			await loginAsTestUser(page);
@@ -73,8 +83,11 @@ test.describe('Test Case Detail Page', () => {
 	test.describe('Edit test case', () => {
 		test.describe.configure({ timeout: 60_000 });
 
-		test('should edit and save test case content on the detail page', async ({ page }) => {
-			const originalTitle = `E2E Edit Case ${Date.now()}`;
+		test('should edit and save test case content on the detail page', async ({
+			page,
+			request
+		}) => {
+			const originalTitle = `E2E Detail Edit ${Date.now()}`;
 			const updatedTitle = `${originalTitle} Updated`;
 			const description = 'Updated description from E2E test';
 			const steps = 'Step 1: Do something\nStep 2: Verify outcome';
@@ -86,6 +99,8 @@ test.describe('Test Case Detail Page', () => {
 			await listPage.waitForLoad();
 			const created = await listPage.createTestCase(originalTitle);
 			expect(created).toBeDefined();
+
+			await waitForTestCaseInApi(request, projectId, created!.id);
 
 			const detailPage = new TestCaseDetailPage(page, projectId, created!.id);
 			await detailPage.navigate();

--- a/e2e/tests/test-cases.test.ts
+++ b/e2e/tests/test-cases.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { TestCasesPage } from '../pages/test-cases';
 import { loginAsTestUser } from '../helpers/auth';
-import { cleanupE2eTestData, getE2eProjectId } from '../helpers/cleanup';
+import { cleanupE2eTestData, E2E_CASES_PREFIX, getE2eProjectId } from '../helpers/cleanup';
 
 /**
  * Test Cases Page E2E Tests
@@ -20,12 +20,12 @@ test.describe('Test Cases Page', () => {
 
 	test.beforeAll(async ({ request }) => {
 		projectId = getE2eProjectId();
-		await cleanupE2eTestData(request, projectId);
+		await cleanupE2eTestData(request, projectId, { prefix: E2E_CASES_PREFIX });
 	});
 
 	test.afterEach(async ({ request }) => {
 		if (projectId) {
-			await cleanupE2eTestData(request, projectId);
+			await cleanupE2eTestData(request, projectId, { prefix: E2E_CASES_PREFIX });
 		}
 	});
 
@@ -89,7 +89,7 @@ test.describe('Test Cases Page', () => {
 		});
 
 		test.skip('should create a new test suite successfully', async ({ page }) => {
-			const suiteName = `E2E Suite ${Date.now()}`;
+			const suiteName = `E2E Cases Suite ${Date.now()}`;
 
 			await testCasesPage.createTestSuite(suiteName);
 
@@ -141,7 +141,7 @@ test.describe('Test Cases Page', () => {
 
 		// TODO: create new project before running this test
 		test.skip('should create a new test case successfully', async ({ page }) => {
-			const testCaseTitle = `E2E Test Case ${Date.now()}`;
+			const testCaseTitle = `E2E Cases TC ${Date.now()}`;
 
 			await testCasesPage.createTestCase(testCaseTitle);
 
@@ -157,7 +157,7 @@ test.describe('Test Cases Page', () => {
 
 		// TODO: create new project before running this test
 		test.skip('should create multiple test cases in quick succession', async ({ page }) => {
-			const baseName = `E2E Batch ${Date.now()}`;
+			const baseName = `E2E Cases Batch ${Date.now()}`;
 			const testCases = [`${baseName} - TC1`, `${baseName} - TC2`, `${baseName} - TC3`];
 
 			// Create first test case
@@ -197,7 +197,7 @@ test.describe('Test Cases Page', () => {
 
 		test('should increment test case count after creating a test case', async () => {
 			const initialStats = await testCasesPage.getStats();
-			const testCaseTitle = `E2E Count Test ${Date.now()}`;
+			const testCaseTitle = `E2E Cases Count ${Date.now()}`;
 
 			await testCasesPage.createTestCase(testCaseTitle);
 			await testCasesPage.reloadAndWait();
@@ -210,14 +210,14 @@ test.describe('Test Cases Page', () => {
 	test.describe('Test Case Modal', () => {
 		test.describe.configure({ timeout: 60_000 });
 		test('should open modal when clicking on a test case', async () => {
-			const testCaseTitle = `E2E Modal Test ${Date.now()}`;
+			const testCaseTitle = `E2E Cases Modal ${Date.now()}`;
 			await testCasesPage.createTestCase(testCaseTitle);
 			await testCasesPage.clickTestCase(testCaseTitle);
 			expect(await testCasesPage.isModalVisible()).toBe(true);
 		});
 
 		test('should display test case information in modal', async () => {
-			const testCaseTitle = `E2E Modal Info Test ${Date.now()}`;
+			const testCaseTitle = `E2E Cases Modal Info ${Date.now()}`;
 			await testCasesPage.createTestCase(testCaseTitle);
 			await testCasesPage.clickTestCase(testCaseTitle);
 
@@ -227,7 +227,7 @@ test.describe('Test Cases Page', () => {
 		});
 
 		test('should close modal when clicking close button', async () => {
-			const testCaseTitle = `E2E Modal Close Test ${Date.now()}`;
+			const testCaseTitle = `E2E Cases Modal Close ${Date.now()}`;
 			await testCasesPage.createTestCase(testCaseTitle);
 			await testCasesPage.clickTestCase(testCaseTitle);
 
@@ -238,7 +238,7 @@ test.describe('Test Cases Page', () => {
 		});
 
 		test('should have "Open Full View" button in modal', async () => {
-			const testCaseTitle = `E2E Full View Test ${Date.now()}`;
+			const testCaseTitle = `E2E Cases Full View ${Date.now()}`;
 			await testCasesPage.createTestCase(testCaseTitle);
 			await testCasesPage.clickTestCase(testCaseTitle);
 			await testCasesPage.assertVisible(testCasesPage.modalOpenFullViewButton);
@@ -247,7 +247,7 @@ test.describe('Test Cases Page', () => {
 		test('should navigate to full test case page when clicking "Open Full View"', async ({
 			page
 		}) => {
-			const testCaseTitle = `E2E Navigation Test ${Date.now()}`;
+			const testCaseTitle = `E2E Cases Navigation ${Date.now()}`;
 			await testCasesPage.createTestCase(testCaseTitle);
 			await testCasesPage.clickTestCase(testCaseTitle);
 
@@ -262,8 +262,8 @@ test.describe('Test Cases Page', () => {
 	test.describe('Suite and Test Case Integration', () => {
 		test.describe.configure({ timeout: 60_000 });
 		test('should create suite and add test case to it', async ({ page }) => {
-			const suiteName = `E2E Integration Suite ${Date.now()}`;
-			const testCaseTitle = `E2E Integration TC ${Date.now()}`;
+			const suiteName = `E2E Cases Integration Suite ${Date.now()}`;
+			const testCaseTitle = `E2E Cases Integration TC ${Date.now()}`;
 
 			// Create suite first
 			await testCasesPage.createTestSuite(suiteName);
@@ -279,7 +279,7 @@ test.describe('Test Cases Page', () => {
 		});
 
 		test('should expand and collapse test suites', async ({ page }) => {
-			const suiteName = `E2E Expand Suite ${Date.now()}`;
+			const suiteName = `E2E Cases Expand Suite ${Date.now()}`;
 
 			// Create a suite
 			await testCasesPage.createTestSuite(suiteName);
@@ -298,7 +298,7 @@ test.describe('Test Cases Page', () => {
 	test.describe('Keyboard Navigation', () => {
 		// TODO: create new project before running this test
 		test.skip('should support keyboard navigation in test case creation', async ({ page }) => {
-			const testCaseTitle = `E2E Keyboard Test ${Date.now()}`;
+			const testCaseTitle = `E2E Cases Keyboard ${Date.now()}`;
 
 			await testCasesPage.clickNewTestCase();
 

--- a/e2e/tests/test-cases.test.ts
+++ b/e2e/tests/test-cases.test.ts
@@ -263,7 +263,6 @@ test.describe('Test Cases Page', () => {
 		test.describe.configure({ timeout: 60_000 });
 		test('should create suite and add test case to it', async ({ page }) => {
 			const suiteName = `E2E Cases Integration Suite ${Date.now()}`;
-			const testCaseTitle = `E2E Cases Integration TC ${Date.now()}`;
 
 			// Create suite first
 			await testCasesPage.createTestSuite(suiteName);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The scheduled Playwright run ([workflow run 28970320494](https://github.com/QAStudio-Dev/studio/actions/runs/28970320494)) failed on:

`test-case-detail.test.ts` → *should open a newly created test case without a server error*

The detail page showed **Test Case Not Found** (404) even though the list page had a persisted case ID.

## Root cause

`test-cases.test.ts` and `test-case-detail.test.ts` both use the same E2E project and both call `cleanupE2eTestData` in `afterEach`. With 4 Playwright workers, tests from both files run in parallel. Cleanup deleted **all** resources whose titles start with `E2E`, so one file could delete a case another file had just created before navigation.

## Fix

- Introduce file-specific prefixes: `E2E Cases` and `E2E Detail`
- Scope `cleanupE2eTestData` to only delete resources matching the caller's prefix
- Add `waitForTestCaseInApi` and use it before opening the detail page to avoid navigating before persistence is visible

## Testing

- `npm run format`
- `npm run check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3295f8c8-a40f-42ad-ac22-d93f8b685667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3295f8c8-a40f-42ad-ac22-d93f8b685667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added scoped cleanup for end-to-end data using dedicated naming prefixes, limiting cleanup to only items created for specific scenarios.
  * Added an API wait helper to ensure newly created test cases are visible in the backend before interacting with the Test Case Detail UI.
  * Updated end-to-end fixture/test naming for consistency across suite and test case flows, including execution history scenarios.

* **Bug Fixes**
  * Reduced flaky behavior in “open” and “edit” test case flows by waiting for backend readiness before UI navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->